### PR TITLE
filter off unknown file types

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ const batch = async (raw, batched) => {
   mkdirp.sync(batched);
   return batchIssue(raw, batched)
     .then(merkleRoot => {
-      logger.info(`Batch Certificate Root: ${merkleRoot}`);
+      logger.info(`Batch Certificate Root: 0x${merkleRoot}`);
       return `${merkleRoot}`;
     })
     .catch(err => {

--- a/src/diskUtils.js
+++ b/src/diskUtils.js
@@ -6,7 +6,7 @@ const { filter, some } = require("lodash");
 const readdir = util.promisify(fs.readdir);
 
 const opencertsFileExtensions = [
-  /(.*)(\.)(opencert|OpenCert|Opencert)$/,
+  /(.*)(\.)(opencert)$/,
   /(.*)(\.)(json)$/
 ];
 
@@ -15,7 +15,7 @@ function readCert(directory, filename) {
 }
 
 function isOpenCertFileExtension(filename) {
-  return some(opencertsFileExtensions.map(mask => mask.test(filename)));
+  return some(opencertsFileExtensions.map(mask => mask.test(filename.toLowerCase())));
 }
 
 function setFilename(filenameMap, documentId, filename) {

--- a/src/diskUtils.js
+++ b/src/diskUtils.js
@@ -1,28 +1,38 @@
 const fs = require("fs");
 const util = require("util");
 const path = require("path");
+const { filter, some } = require("lodash");
 
 const readdir = util.promisify(fs.readdir);
 
+const opencertsFileExtensions = [
+  /(.*)(\.)(opencert|OpenCert|Opencert)$/,
+  /(.*)(\.)(json)$/
+];
+
 function readCert(directory, filename) {
   return JSON.parse(fs.readFileSync(path.join(directory, filename)));
+}
+
+function isOpenCertFileExtension(filename) {
+  return some(opencertsFileExtensions.map(mask => mask.test(filename)));
 }
 
 function setFilename(filenameMap, documentId, filename) {
   return Object.assign(filenameMap, { [documentId]: filename });
 }
 
-function getRawCertificates(unsignedCertDir) {
+async function getRawCertificates(unsignedCertDir) {
   const unsignedCertDirPath = path.resolve(unsignedCertDir);
-  return readdir(unsignedCertDirPath).then(items => {
-    let filenameMap = {};
-    const certificates = items.map(filename => {
-      const document = readCert(unsignedCertDirPath, filename);
-      filenameMap = setFilename(filenameMap, document.id, filename);
-      return document;
-    });
-    return { filenameMap, certificates };
+  const items = await readdir(unsignedCertDirPath);
+  const certFiles = filter(items, isOpenCertFileExtension);
+  let filenameMap = {};
+  const certificates = certFiles.map(filename => {
+    const document = readCert(unsignedCertDirPath, filename);
+    filenameMap = setFilename(filenameMap, document.id, filename);
+    return document;
   });
+  return { filenameMap, certificates };
 }
 
 function writeCertToDisk(destinationDir, filename, certificate) {


### PR DESCRIPTION
Added filetype masks for .OpenCert, .Opencert, .opencert and .json